### PR TITLE
[better-pipe-order] Implement new pipe params order and its tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2020-05-17
+### Changed
+- UseCase.pipe params order
+
 ## [0.1.4] - 2020-05-16
 ### Changed
 - Docs improved

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ end
 We can compose with our `SayHello` simple as that:
 
 ```elixir
-iex> UseCase.pipe [SayHello, LogOperation], %SayHello{name: "Henrique"}
+iex> %SayHello{name: "Henrique"} |> UseCase.pipe [SayHello, LogOperation]
 iex> {:ok, LogOperation.Output{_state: nil}}
 
 iex> UseCase.pipe [%SayHello{name: "Henrique"}, LogOperation] 
@@ -226,6 +226,9 @@ iex> {:ok, LogOperation.Output{_state: nil}}
 
 iex> UseCase.pipe [%SayHello{name: nil}, LogOperation] 
 iex> {:error, SayHello.Error{message: "name is obrigatory!", code: 500}}
+
+iex> %SayHello{name: "Henrique"} |> UseCase.pipe! [SayHello, LogOperation]
+iex> LogOperation.Output{_state: nil}
 
 iex> UseCase.pipe! [%SayHello{name: "Henrique"}, LogOperation] 
 iex> LogOperation.Output{_state: nil}
@@ -244,8 +247,8 @@ All `UseCase` functions last argument is the options keyword list that is sent t
 import UseCase
 
 call(%SayHello{name: "henrique"}, my_option: true)
+%SayHello{name: "Henrique"} |> pipe([SayHello, LogOperation], my_option: true)
 pipe([%SayHello{name: "Henrique"}, LogOperation], my_option: true)
-pipe([SayHello, LogOperation], %SayHello{name: "Henrique"}, my_option: true)
 ```
 
 ## Contribute

--- a/lib/use_case.ex
+++ b/lib/use_case.ex
@@ -1,11 +1,12 @@
 defmodule UseCase do
-  def pipe([interactor | _] = interactors, input, opts) when is_atom(interactor),
+  def pipe(input, [interactor | _] = interactors, opts) when is_atom(interactor),
     do: pipe_loop(interactors, input, opts)
 
-  def pipe([interactor | _] = interactors, input) when is_atom(interactor),
+  def pipe(input, [interactor | _] = interactors) when is_atom(interactor),
     do: pipe_loop(interactors, input, [])
 
   def pipe(interactors, opts), do: pipe_loop(interactors, opts)
+
   def pipe(interactors), do: pipe_loop(interactors, [])
 
   defp pipe_loop([], input, _opts), do: {:ok, input}
@@ -18,13 +19,14 @@ defmodule UseCase do
     with {:ok, output} <- call(interactor, opts), do: pipe_loop(interactors, output, opts)
   end
 
-  def pipe!([interactor | _] = interactors, input, opts) when is_atom(interactor),
+  def pipe!(input, [interactor | _] = interactors, opts) when is_atom(interactor),
     do: pipe_loop!(interactors, input, opts)
 
-  def pipe!([interactor | _] = interactors, input) when is_atom(interactor),
+  def pipe!(input, [interactor | _] = interactors) when is_atom(interactor),
     do: pipe_loop!(interactors, input, [])
 
   def pipe!(interactors, opts), do: pipe_loop!(interactors, opts)
+
   def pipe!(interactors), do: pipe_loop!(interactors, [])
 
   defp pipe_loop!([], output, _opts), do: output

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,8 @@ defmodule UseCase.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      description: "A way to increase Elixir projects readability and maintenance based on Use Cases and Interactors.",
+      description:
+        "A way to increase Elixir projects readability and maintenance based on Use Cases and Interactors.",
       package: package(),
       docs: [logo: "priv/static/logo.png", extras: ["README.md"], main: "readme"],
       name: "UseCase",

--- a/test/use_case_test.exs
+++ b/test/use_case_test.exs
@@ -91,7 +91,7 @@ defmodule UseCaseTest do
   describe "UseCase.pipe/3" do
     test "it call's interactors with correct params and opts" do
       interactors = [FakeInteractor, FakeInteractorTwo, FakeInteractorThree]
-      result = UseCase.pipe(interactors, %{some_value: "test"}, my_option: "test")
+      result = UseCase.pipe(%{some_value: "test"}, interactors, my_option: "test")
 
       assert_received {%{some_value: "test"}, [my_option: "test"]}
       assert_received {%FakeInteractor.Output{}, [my_option: "test"]}
@@ -101,7 +101,7 @@ defmodule UseCaseTest do
 
     test "if some interactor fails, returns the failed return" do
       interactors = [FakeInteractor, FakeInteractorTwo, FakeInteractorThree]
-      result = UseCase.pipe(interactors, %{some_value: "test"}, my_option: "fail_two")
+      result = UseCase.pipe(%{some_value: "test"}, interactors, my_option: "fail_two")
 
       assert_received {%{some_value: "test"}, [my_option: "fail_two"]}
       assert_received {%FakeInteractor.Output{}, [my_option: "fail_two"]}
@@ -113,7 +113,7 @@ defmodule UseCaseTest do
   describe "UseCase.pipe!/3" do
     test "it call's interactors with correct params and opts" do
       interactors = [FakeInteractor, FakeInteractorTwo, FakeInteractorThree]
-      result = UseCase.pipe!(interactors, %{some_value: "test"}, my_option: "test")
+      result = UseCase.pipe!(%{some_value: "test"}, interactors, my_option: "test")
 
       assert_received {%{some_value: "test"}, [my_option: "test"]}
       assert_received {%FakeInteractor.Output{}, [my_option: "test"]}
@@ -125,7 +125,7 @@ defmodule UseCaseTest do
       interactors = [FakeInteractor, FakeInteractorTwo, FakeInteractorThree]
 
       assert_raise FakeInteractorTwo.Error, fn ->
-        UseCase.pipe!(interactors, %{some_value: "test"}, my_option: "fail_two")
+        UseCase.pipe!(%{some_value: "test"}, interactors, my_option: "fail_two")
       end
 
       assert_received {%{some_value: "test"}, [my_option: "fail_two"]}


### PR DESCRIPTION
The asymmetry in the argument list (struct followed by N atoms) feelt weird. It also doesn’t seem particularly friendly to composition